### PR TITLE
Fix svg alignment in safari

### DIFF
--- a/src/views/svg.ejs
+++ b/src/views/svg.ejs
@@ -10,7 +10,7 @@
       }
     </style>
   </defs>
-  <text x="50" y="50" style="alignment-baseline:central;text-anchor:middle;fill:#fff;font-weight:bold;font-family:Open Sans;font-size:55px;">
+  <text x="50" y="50" style="alignment-baseline:middle;text-anchor:middle;fill:#fff;font-weight:bold;font-family:Open Sans;font-size:55px;">
     <%= text %>
   </text>
 </svg>

--- a/src/views/svg.ejs
+++ b/src/views/svg.ejs
@@ -10,7 +10,7 @@
       }
     </style>
   </defs>
-  <text x="50" y="85" style="dominant-baseline:ideographic;text-anchor:middle;fill:#fff;font-weight:bold;font-family:Open Sans;font-size:55px;">
+  <text x="50" y="50" style="alignment-baseline:central;text-anchor:middle;fill:#fff;font-weight:bold;font-family:Open Sans;font-size:55px;">
     <%= text %>
   </text>
 </svg>


### PR DESCRIPTION
Before:
<img width="111" alt="screen shot 2016-10-03 at 11 17 27 am" src="https://cloud.githubusercontent.com/assets/3363898/19044696/025622e0-895b-11e6-9c11-65f5b6abb0d6.png">

After:
<img width="117" alt="screen shot 2016-10-03 at 11 17 08 am" src="https://cloud.githubusercontent.com/assets/3363898/19044699/069d5f44-895b-11e6-850f-13ea617b807a.png">

Closes #21 🎃 